### PR TITLE
Fixed a crash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,9 +59,9 @@ static void initTasks(/* void* taskStacksMemory */)
        So, this implementation of the function is different (but logically the same).
     */
 
-    g_taskGameMainLoop = addTask(taskGameMainLoop());
-    addTask(taskMouseEventHandling());
     addTask(taskSpawnTrains());
+    addTask(taskMouseEventHandling());
+    g_taskGameMainLoop = addTask(taskGameMainLoop());
 
     runScheduler();
 }

--- a/src/tasks/task.h
+++ b/src/tasks/task.h
@@ -14,8 +14,14 @@ struct TaskPromise;
 struct Context {
     using Time = std::chrono::steady_clock::time_point;
 
+    Context(unsigned priority)
+        : m_priority(priority)
+    {
+    }
+
     // a newly created task has a highest execution priority
     Time m_sleepUntil = {};
+    unsigned m_priority;
     bool m_suspended = false;
 };
 


### PR DESCRIPTION
The scheduler didn't always guarantee that the last added task would be executed next. But the original game riles on that. This was a cause of the crash then starting the game under Windows.