### PR TITLE
misc: use C++20 concepts instead of SFINAE

### DIFF
--- a/src/game/savefile/load_game.cpp
+++ b/src/game/savefile/load_game.cpp
@@ -96,7 +96,7 @@ namespace {
         return false;
     }
 
-    template <typename T, typename Enable = void>
+    template <typename T>
     class DataReader;
 
     class Reader {
@@ -205,7 +205,8 @@ namespace {
     };
 
     template <typename T>
-    class DataReader<T, std::enable_if_t<std::is_integral_v<T>>> {
+    requires std::is_integral_v<T>
+    class DataReader<T> {
     public:
         static std::optional<T> read(Reader& r)
         {
@@ -230,7 +231,8 @@ namespace {
     };
 
     template <typename T>
-    class DataReader<T, std::enable_if_t<std::is_enum_v<T>>> {
+    requires std::is_enum_v<T>
+    class DataReader<T> {
     public:
         static std::optional<T> read(Reader& r)
         {

--- a/src/game/savefile/save_game.cpp
+++ b/src/game/savefile/save_game.cpp
@@ -52,7 +52,7 @@ namespace {
     static_assert(g_railsVirtualOffset + fileRailSize < g_entrancesVirtualOffset);
     static_assert(g_entrancesVirtualOffset + fileEntrancesArraySize <= std::numeric_limits<std::uint16_t>::max());
 
-    template <typename T, typename Enable = void>
+    template <typename T>
     class DataWriter;
 
     class Writer {
@@ -123,7 +123,8 @@ namespace {
     };
 
     template <typename T>
-    class DataWriter<T, std::enable_if_t<std::is_integral_v<T>>> {
+    requires std::is_integral_v<T>
+    class DataWriter<T> {
     public:
         static void write(Writer& w, T value)
         {
@@ -133,7 +134,8 @@ namespace {
     };
 
     template <typename T>
-    class DataWriter<T, std::enable_if_t<std::is_enum_v<T>>> {
+    requires std::is_enum_v<T>
+    class DataWriter<T> {
     public:
         static void write(Writer& w, T value)
         {


### PR DESCRIPTION
Minimum required C++ standard version is 20, so we can freely use concepts instead of SFINAE in the form of `std::enable_if` constructs.

This makes code a little bit easier to read and improves compiler diagnostics.