### PR TITLE
Fixed flickering of screen during animation

### DIFF
--- a/src/system/driver/sdl/video.cpp
+++ b/src/system/driver/sdl/video.cpp
@@ -88,33 +88,28 @@ void VGAEmulation::flush()
             }
 
         } else {
+            const int overflowLinePhysicalY =
+                m_vgaState.overflowLineCompare * m_wndHeight / LOGICAL_SCREEN_HEIGHT;
             if (m_vgaState.overflowLineCompare < LOGICAL_SCREEN_HEIGHT) {
-                SDL_Rect srcRect = {
-                    0, m_vgaState.yOrigin,
-                    LOGICAL_SCREEN_WIDTH, m_vgaState.overflowLineCompare
-                };
-                SDL_Rect dstRect = {
-                    0,
-                    0,
-                    m_wndWidth,
-                    m_vgaState.overflowLineCompare * m_wndHeight / LOGICAL_SCREEN_HEIGHT,
-                };
-                SDL_RenderCopy(m_renderer, m_screen, &srcRect, &dstRect);
+                SDL_Rect clipRect = { 0, 0, m_wndWidth, overflowLinePhysicalY };
+                SDL_RenderSetClipRect(m_renderer, &clipRect);
+            }
 
+            SDL_Rect srcRect = { 0, m_vgaState.yOrigin, LOGICAL_SCREEN_WIDTH, LOGICAL_SCREEN_HEIGHT };
+            SDL_RenderCopy(m_renderer, m_screen, &srcRect, nullptr);
+
+            SDL_RenderSetClipRect(m_renderer, nullptr);
+
+            if (m_vgaState.overflowLineCompare < LOGICAL_SCREEN_HEIGHT) {
                 srcRect = {
                     0, 0,
                     LOGICAL_SCREEN_WIDTH, LOGICAL_SCREEN_HEIGHT - m_vgaState.overflowLineCompare
                 };
-                dstRect = {
-                    0,
-                    m_vgaState.overflowLineCompare * m_wndHeight / LOGICAL_SCREEN_HEIGHT,
+                SDL_Rect dstRect = {
+                    0, overflowLinePhysicalY,
                     m_wndWidth,
                     (LOGICAL_SCREEN_HEIGHT - m_vgaState.overflowLineCompare) * m_wndHeight / LOGICAL_SCREEN_HEIGHT,
                 };
-                SDL_RenderCopy(m_renderer, m_screen, &srcRect, &dstRect);
-            } else {
-                SDL_Rect srcRect = { 0, m_vgaState.yOrigin, LOGICAL_SCREEN_WIDTH, LOGICAL_SCREEN_HEIGHT };
-                SDL_Rect dstRect = { 0, 0, m_wndWidth, m_wndHeight };
                 SDL_RenderCopy(m_renderer, m_screen, &srcRect, &dstRect);
             }
         }


### PR DESCRIPTION
During the screen switching animation, the image scale changed slightly due to rounding errors in integer arithmetic, which resulted in flickering.

The issue was introduced in the commit:
https://github.com/konovalov-aleks/reSL/commit/0782d8b56843b9e601d477aece98d514fbd6e214